### PR TITLE
fix：enhance SHOW statement detection with optional modifiers(FULL, …

### DIFF
--- a/database/service.py
+++ b/database/service.py
@@ -168,6 +168,7 @@ class DatabaseService:
 
     # Query type prefixes for efficient classification
     _QUERY_TYPE_PREFIXES: tuple[tuple[str, QueryType], ...] = (
+        ("WITH", QueryType.SELECT),  # CTE queries return result sets like SELECT
         ("SELECT", QueryType.SELECT),
         ("INSERT", QueryType.INSERT),
         ("UPDATE", QueryType.UPDATE),

--- a/tests/database/test_service.py
+++ b/tests/database/test_service.py
@@ -356,6 +356,12 @@ class TestDatabaseService:
         service = DatabaseService()
         assert service._classify_query("UNKNOWN COMMAND") == QueryType.OTHER
 
+    def test_classify_query_with_cte(self):
+        """Test query classification for CTE (WITH clause)."""
+        service = DatabaseService()
+        assert service._classify_query("WITH cte AS (SELECT 1) SELECT * FROM cte") == QueryType.SELECT
+        assert service._classify_query("WITH RECURSIVE cte AS (SELECT 1) SELECT * FROM cte") == QueryType.SELECT
+
     def test_classify_query_empty(self):
         """Test query classification for empty query."""
         service = DatabaseService()


### PR DESCRIPTION
Problem
[SHOW FULL PROCESSLIST](vscode-file://vscode-app/Users/wangruixuan/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [SHOW GLOBAL VARIABLES](vscode-file://vscode-app/Users/wangruixuan/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), and CTE queries (WITH...) were routed to LLM instead of direct SQL execution, wasting tokens and performance.

Solution
Strip optional modifiers (FULL, GLOBAL, SESSION, EXTENDED, MASTER, SLAVE, REPLICA) before validating SHOW targets
Recognize WITH queries as [SELECT](vscode-file://vscode-app/Users/wangruixuan/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) type for CTE support
Changes
Enhanced [is_sql_statement()](vscode-file://vscode-app/Users/wangruixuan/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [_classify_query()](vscode-file://vscode-app/Users/wangruixuan/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [service.py](vscode-file://vscode-app/Users/wangruixuan/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added tests: [test_is_sql_statement_show_with_modifiers](vscode-file://vscode-app/Users/wangruixuan/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [test_classify_query_with_cte](vscode-file://vscode-app/Users/wangruixuan/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
All 70 tests pass

Before:
<img width="1750" height="1100" alt="image" src="https://github.com/user-attachments/assets/9730ccee-f62e-4c98-8a40-58736b47764b" />
<img width="1780" height="370" alt="image" src="https://github.com/user-attachments/assets/c306b240-9a46-4606-9eb5-f32d946b2ade" />
<img width="1766" height="878" alt="image" src="https://github.com/user-attachments/assets/1d486143-29ba-4f55-b709-4cd35f233dc5" />

After:
<img width="1734" height="642" alt="image" src="https://github.com/user-attachments/assets/c1d1c3b4-727a-427d-a7ef-831fa4f15683" />
<img width="1766" height="412" alt="image" src="https://github.com/user-attachments/assets/a730cc25-e0e3-47c0-a91d-ea1e63c652e4" />
